### PR TITLE
automatic unlocking accounts with 30 minute rate

### DIFF
--- a/src/main/java/ed/biodare2/backend/security/dao/UserAccountRep.java
+++ b/src/main/java/ed/biodare2/backend/security/dao/UserAccountRep.java
@@ -11,6 +11,8 @@ import ed.biodare2.backend.security.dao.db.UserAccount;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 /**
  *
@@ -29,4 +31,8 @@ public interface UserAccountRep extends JpaRepository<UserAccount, Long> {
     List<UserAccount> findByLoginOrEmailOrInitialEmail(String identifier, String identifier0, String identifier1);
     
     List<UserAccount> findBySubscriptionKind(SubscriptionType subscription);
+    
+    @Modifying
+    @Query("UPDATE UserAccount u SET u.locked = false, u.failedAttempts = 0 WHERE u.locked = true")
+    void unlockExpiredAccounts();    
 }

--- a/src/main/java/ed/biodare2/backend/web/listeners/AccountsLocker.java
+++ b/src/main/java/ed/biodare2/backend/web/listeners/AccountsLocker.java
@@ -21,6 +21,7 @@ import org.springframework.security.web.authentication.WebAuthenticationDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.scheduling.annotation.Scheduled;
 
 /**
  *
@@ -92,4 +93,12 @@ public class AccountsLocker {
             
         }
     }
+    
+    @Scheduled(fixedRate = 30*60*1000, initialDelay = 1*60*1000)
+    @Transactional
+    public void unlockAccounts() {
+        log.info("Unlocking accounts");
+        users.unlockExpiredAccounts();
+    }
+    
 }


### PR DESCRIPTION
It was a pain, as I could not pull JC and build the SB updated BioDare.

I could not run the whole build/test as there are missing configurations for your stats module.

The unlocking happens every 30 minutes (so some account could unlocked after 1 minute another after 30 minutes).
(by [AccountsLocker.java](https://github.com/BioDare2/bd2-backend/compare/account-unlocking?expand=1#diff-aca9db85c119e22cc579ba46e10860613bd30bfd0d056d53cd2eb174ab0900f7)).

You should see, message in the logs "Unlocking accounts" after one minute from the start.